### PR TITLE
build: setup build for server, client and common andsetup CMake and Conan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,19 +32,64 @@
 *.exe
 *.out
 *.app
+r-type_server
+r-type_client
+
+# Build
+build/
+
+### CMake / Conan
+
+# CMake generated files
+CMakeUserPresets.json.user
+
+# Conan build information
+conan.lock
+conanbuildinfo.*
+conaninfo.txt
+graph_info.json
+
+# CMake Build Artifacts
+CMakeFiles/
+build.ninja
+cmake_install.cmake
+CMakeCache.txt
+
+# Conan Artifacts
+conan/
+conan_host_profile
+conan_provider.cmake
+
+# Testing/Temporary Files
+Testing/
+
+# Temporary / Environment-Specific Files
+.cmake/
+
+## Various built-in generators
+# cmake_find_package generator https://docs.conan.io/en/latest/reference/generators/cmake_find_package.html
+Find*.cmake
+
+# cmake_paths generator https://docs.conan.io/en/1.4/integrations/cmake/cmake_paths_generator.html
+conan_paths.*
+
+# Environment activation scripts produced by https://docs.conan.io/en/latest/mastering/virtualenv.html#virtualenv-generator
+activate_run.ps1
+activate_run.sh
+deactivate_run.ps1
+deactivate_run.sh
+environment_run.ps1.env
+environment_run.sh.env
 
 ### JetBrains
 
-.idea
+.idea/
 *.iml
 out
 gen
 
 # CMake
 cmake-build-*/
-
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
 
 # File-based project format
 *.iws
@@ -63,15 +108,20 @@ fabric.properties
 
 ### VSCode
 
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/
 
 # Local History for Visual Studio Code
 .history/
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+### Other
+
+# Logs and temporary files
+*.log
+*.tmp
+
+# OS-specific files
+.DS_Store
+Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.29)
+project(R_Type VERSION 0.0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+find_package(spdlog REQUIRED)
+
+add_subdirectory(common)
+add_subdirectory(server)
+add_subdirectory(client)

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -1,0 +1,9 @@
+{
+    "version": 4,
+    "vendor": {
+        "conan": {}
+    },
+    "include": [
+        "cmake-build-debug/conan/build/Debug/generators/CMakePresets.json"
+    ]
+}

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(CLIENT_SRC
+        src/main.cpp
+)
+
+set(CLIENT_HEADERS
+        include/foo.hpp
+)
+
+add_executable(r-type_client ${CLIENT_SRC} ${CLIENT_HEADERS})
+target_include_directories(r-type_client PUBLIC include)
+target_link_libraries(r-type_client PRIVATE r-type_common)

--- a/client/include/foo.hpp
+++ b/client/include/foo.hpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2024
+** R_Type
+** File description:
+** foo.hpp
+*/
+
+#ifndef FOO_HPP_
+#define FOO_HPP_
+
+// TODO: this is a sample file, remove it once a real one is created
+
+#endif /* !FOO_HPP_ */

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** main.cpp
+*/
+
+#include "spdlog/spdlog.h"
+
+int main() {
+    spdlog::info("R-Type client launched"); // // TODO: this is a sample log, remove it
+    return 0;
+}

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(COMMON_SRC
+        src/foo.cpp
+)
+
+set(COMMON_HEADERS
+        include/foo.hpp
+)
+
+add_library(r-type_common STATIC ${COMMON_SRC} ${COMMON_HEADERS})
+target_include_directories(r-type_common PUBLIC include)
+target_link_libraries(r-type_common PUBLIC spdlog::spdlog)

--- a/common/include/foo.hpp
+++ b/common/include/foo.hpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2024
+** R_Type
+** File description:
+** foo.hpp
+*/
+
+#ifndef FOO_HPP_
+#define FOO_HPP_
+
+// TODO: this is a sample file, remove it once a real one is created
+
+#endif /* !FOO_HPP_ */

--- a/common/src/foo.cpp
+++ b/common/src/foo.cpp
@@ -1,0 +1,8 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** main.cpp
+*/
+
+// TODO: this is a sample file, remove it once a real one is created

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+spdlog/1.15.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SERVER_SRC
+        src/main.cpp
+)
+
+set(SERVER_HEADERS
+        include/foo.hpp
+)
+
+add_executable(r-type_server ${SERVER_SRC} ${SERVER_HEADERS})
+target_include_directories(r-type_server PUBLIC include)
+target_link_libraries(r-type_server PRIVATE r-type_common)

--- a/server/include/foo.hpp
+++ b/server/include/foo.hpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2024
+** R_Type
+** File description:
+** foo.hpp
+*/
+
+#ifndef FOO_HPP_
+#define FOO_HPP_
+
+// TODO: this is a sample file, remove it once a real one is created
+
+#endif /* !FOO_HPP_ */

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2024
+** R-Type
+** File description:
+** main.cpp
+*/
+
+#include "spdlog/spdlog.h"
+
+int main() {
+    spdlog::info("R-Type server launched on port 4242"); // // TODO: this is a sample log, remove it
+    return 0;
+}


### PR DESCRIPTION
## Description

Setup build (with **CMake**) and packages management (with **Conan**).
Build will produce one library and two executables:
- `r-type_common`
- `r-type_server`
- `r-type_client`

All is explained on the wiki, at this page: [Build and manage packages](https://github.com/Z4RM/Epitech-Tek3-CPP-R-Type/wiki/Build-and-manage-packages).

## Related Issue

Closes #2 

## Checklist

- [ ] Tests*
  - [ ] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [ ] I have tested on Linux.
  - [ ] I have tested on Windows.
- [x] Documentation
  - [x] I have updated the Wiki (if needed).
  - [ ] I have documented for Linux AND Windows (if different).**

*Actually, I only have tested with **CLion** (as you can see in the wiki), other tests will be made later, but we need this to start to work.
**As you can see also in the wiki, it's planned for later.

## Known Issues

Build instructions for terminals and VSCode must be added to the wiki page (#10).
