### PR TITLE
feat: add mode manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(RTYPE_SRC
         src/ECS/EntityManager.hpp
         src/ECS/SparseSet.hpp
         src/ECS/SystemManager.hpp
+        src/RType/ModeManager/ModeManager.cpp
+        src/RType/ModeManager/ModeManager.hpp
 )
 
 set(RTYPE_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 find_package(spdlog REQUIRED)
 
+include_directories(include src)
+
 set(RTYPE_SRC
         src/main.cpp
         src/ECS/ComponentManager.hpp
@@ -21,22 +23,18 @@ set(RTYPE_HEADERS
         include/foo.hpp
 )
 
-#region Client
-add_executable(r-type_client ${RTYPE_SRC} ${RTYPE_HEADERS})
-
-target_compile_definitions(r-type_client PRIVATE RTYPE_IS_CLIENT)
-
-target_include_directories(r-type_client PUBLIC include)
-
-target_link_libraries(r-type_client PRIVATE spdlog::spdlog)
-#endregion
-
 #region Server
 add_executable(r-type_server ${RTYPE_SRC} ${RTYPE_HEADERS})
 
 target_compile_definitions(r-type_server PRIVATE RTYPE_IS_SERVER)
 
-target_include_directories(r-type_server PUBLIC include)
-
 target_link_libraries(r-type_server PRIVATE spdlog::spdlog)
+#endregion
+
+#region Client
+add_executable(r-type_client ${RTYPE_SRC} ${RTYPE_HEADERS})
+
+target_compile_definitions(r-type_client PRIVATE RTYPE_IS_CLIENT)
+
+target_link_libraries(r-type_client PRIVATE spdlog::spdlog)
 #endregion

--- a/src/RType/ModeManager/ModeManager.cpp
+++ b/src/RType/ModeManager/ModeManager.cpp
@@ -1,0 +1,40 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** ModeManager.cpp
+*/
+
+#include "spdlog/spdlog.h"
+#include "ModeManager.hpp"
+
+void rtype::ModeManager::enableServer() {
+    std::lock_guard<std::mutex> lock(_modeMutex);
+    _isServer = true;
+    spdlog::debug("Server mode enabled");
+}
+
+void rtype::ModeManager::disableServer() {
+    std::lock_guard<std::mutex> lock(_modeMutex);
+    _isServer = false;
+    spdlog::debug("Server mode disabled");
+}
+
+void rtype::ModeManager::switchServer() {
+    if (_isServer)
+        disableServer();
+    else
+        enableServer();
+}
+
+bool rtype::ModeManager::isServer() {
+    return _isServer;
+}
+
+#ifdef RTYPE_IS_SERVER
+bool rtype::ModeManager::_isServer = true;
+#else
+bool rtype::ModeManager::_isServer = false;
+#endif
+
+std::mutex rtype::ModeManager::_modeMutex;

--- a/src/RType/ModeManager/ModeManager.cpp
+++ b/src/RType/ModeManager/ModeManager.cpp
@@ -8,6 +8,14 @@
 #include "spdlog/spdlog.h"
 #include "ModeManager.hpp"
 
+#ifdef RTYPE_IS_SERVER
+
+bool rtype::ModeManager::isServer() {
+    return true;
+}
+
+#else
+
 void rtype::ModeManager::enableServer() {
     std::lock_guard<std::mutex> lock(_modeMutex);
     _isServer = true;
@@ -31,10 +39,8 @@ bool rtype::ModeManager::isServer() {
     return _isServer;
 }
 
-#ifdef RTYPE_IS_SERVER
-bool rtype::ModeManager::_isServer = true;
-#else
 bool rtype::ModeManager::_isServer = false;
-#endif
 
 std::mutex rtype::ModeManager::_modeMutex;
+
+#endif

--- a/src/RType/ModeManager/ModeManager.hpp
+++ b/src/RType/ModeManager/ModeManager.hpp
@@ -1,0 +1,96 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** ModeManager.hpp
+*/
+
+#ifndef RTYPE_MODEMANAGER_HPP_
+#define RTYPE_MODEMANAGER_HPP_
+
+#include <mutex>
+
+namespace rtype {
+    /**
+     * @class ModeManager
+     *
+     * @brief Manages the program mode (server, client, client with server).
+     * It allows to get the current state of the server (enabled or disabled) and to enable or disable it.
+     *
+     * @warning This class doesn't have client state management, because it's not supposed to change.
+     * To add only-client code, use preprocessor directives, so the server binary doesn't have useless client code.
+     * Example of code conditionally compiled using preprocessor directives (you can also refer to `ModeManager.cpp`):
+     * ```cpp
+     * #ifdef RTYPE_IS_CLIENT
+     * // Some code only included in client binary here...
+     * #endif
+     * ```
+     */
+    class ModeManager {
+    public:
+        /**
+         * @brief Enables the server part (intended to be used only by client).
+         */
+        static void enableServer();
+
+        /**
+         * @brief Disables the server part (intended to be used only by client).
+         */
+        static void disableServer();
+
+        /**
+         * @brief Switches the server part state (intended to be used only by client).
+         * If it was enabled, it's disabled.
+         * Otherwise, if it was disabled, it's enabled.
+         */
+        static void switchServer();
+
+        /**
+         * @return Whether the current program is a server (or a client with a server) or not.
+         */
+        static bool isServer();
+
+    private:
+        /**
+         * @brief Current state of the server (enabled or disabled).
+         * Always `true` on server, unless `disableServer` is called (not supposed to happen).
+         * By default `false` on client, can be switch to `true` if `enableServer` is called.
+         */
+        static bool _isServer;
+
+        /**
+         * @brief Mutex to keep same state on all threads, so the usage of this class is thread-safe.
+         */
+        static std::mutex _modeMutex;
+    };
+}
+
+/**
+ * @brief Macro to get the current state of the server.
+ *
+ * @see rtype::ModeManager::isServer
+ */
+#define IS_SERVER rtype::ModeManager::isServer()
+
+/**
+ * @brief Macro to enable the server.
+ *
+ * @see rtype::ModeManager::enableServer
+ */
+#define ENABLE_SERVER() rtype::ModeManager::enableServer()
+
+/**
+ * @brief Macro to disable the server.
+ *
+ * @see rtype::ModeManager:disableServer
+ */
+#define DISABLE_SERVER() rtype::ModeManager::disableServer()
+
+/**
+ * @brief Macro to switch the state of the server.
+ *
+ * @see rtype::ModeManager::switchServer
+ */
+#define SWITCH_SERVER() rtype::ModeManager::switchServer()
+
+#endif /* !RTYPE_MODEMANAGER_HPP_ */

--- a/src/RType/ModeManager/ModeManager.hpp
+++ b/src/RType/ModeManager/ModeManager.hpp
@@ -8,6 +8,26 @@
 #ifndef RTYPE_MODEMANAGER_HPP_
 #define RTYPE_MODEMANAGER_HPP_
 
+#ifdef RTYPE_IS_SERVER
+
+namespace rtype {
+    /**
+     * @class ModeManager
+     *
+     * @brief Manages the program mode (server, client, client with server).
+     * It allows to get the current state of the server (enabled or disabled).
+     *
+     * @warning Because this code is only in the server binary, only the `isServer` method is available (which always returns `true`),
+     * because the server cannot be disabled from this server binary.
+     */
+    class ModeManager {
+    public:
+        static bool isServer();
+    };
+}
+
+#else
+
 #include <mutex>
 
 namespace rtype {
@@ -25,28 +45,31 @@ namespace rtype {
      * // Some code only included in client binary here...
      * #endif
      * ```
+     *
+     * @warning Because the server (part) state is intended to be modified only on the client, this class is differently defined on the server and the client.
+     * This following implementation is only for the client.
      */
     class ModeManager {
     public:
         /**
-         * @brief Enables the server part (intended to be used only by client).
+         * @brief Enables the server part.
          */
         static void enableServer();
 
         /**
-         * @brief Disables the server part (intended to be used only by client).
+         * @brief Disables the server part.
          */
         static void disableServer();
 
         /**
-         * @brief Switches the server part state (intended to be used only by client).
+         * @brief Switches the server part state.
          * If it was enabled, it's disabled.
          * Otherwise, if it was disabled, it's enabled.
          */
         static void switchServer();
 
         /**
-         * @return Whether the current program is a server (or a client with a server) or not.
+         * @return Whether the program has the server part enabled or not.
          */
         static bool isServer();
 
@@ -64,13 +87,6 @@ namespace rtype {
         static std::mutex _modeMutex;
     };
 }
-
-/**
- * @brief Macro to get the current state of the server.
- *
- * @see rtype::ModeManager::isServer
- */
-#define IS_SERVER rtype::ModeManager::isServer()
 
 /**
  * @brief Macro to enable the server.
@@ -92,5 +108,14 @@ namespace rtype {
  * @see rtype::ModeManager::switchServer
  */
 #define SWITCH_SERVER() rtype::ModeManager::switchServer()
+
+#endif
+
+/**
+ * @brief Macro to get the current state of the server.
+ *
+ * @see rtype::ModeManager::isServer
+ */
+#define IS_SERVER rtype::ModeManager::isServer()
 
 #endif /* !RTYPE_MODEMANAGER_HPP_ */


### PR DESCRIPTION
## Description

The mode manager is an utility class (`rtype::ModeManager`).
Depending on if the class is compiled with the server or the client, it will not have the same behaviour (using preprocessor directives).
- If it's defined on the server, the class only defines one method, `isServer` (`rtype::ModeManager::isServer`). It always returns `true` (since the server is server, and cannot disable itself).
- If it's defined on the client:
  - The same method (`rtype::ModeManager::isServer`) as the one on the server is defined. However, it returns either `false` or `true`, depending on the current (server) state - which is `false` by default.
  - 3 methods to enable, disable, and switch (enable => disable and vice versa) the server part.

This class is thread-safe (when compiled on client, no need to handle threads when compiled on server).
There is also different macros defined to avoid writing `rtype::ModeManager::<method>` (see end of `src/RType/ModeManager/ModeManager.hpp`).

## Related Issue

Closes #16 

## Checklist

- [ ] Tests
  - [x] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [x] I have tested on Linux.
  - [ ] I have tested on Windows.
- [ ] Documentation
  - [x] I have documented my functions with Doxygen comments.
  - [x] I have updated the Wiki (if needed).
  - [ ] I have documented for Linux AND Windows (if different).
