### PR TITLE
docs(contributing): remove server and client development branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,7 @@ To ensure clarity and structure, follow these guidelines when naming branches:
 ### Types of Branches
 
 - **main**: The primary branch containing production-ready code.
-- **dev/dev**: The primary development branch containing pre-production code.
-- **dev/server**: The primary development branch of the server.
-- **dev/client**: The primary development branch of the client.
+- **dev**: The primary development branch containing pre-production code.
 - A branch type can be either a *Conventional Commit* type (cf. [Commit Message Conventions](#commit-message-conventions)) (except `feat` (replaced by `feature`), `chore` and `style` (both for minor changes, no need to do a branch)), or:
   - **`feature`**: For developing new features.
   - **`hotfix`**: For urgent fixes to production.


### PR DESCRIPTION
## Description

Remove server (`dev/server`) and client (`dev/client`) branches and rename `dev/dev` one into simply `dev`.

Since we use an isomorphic code architecture, there isn't really need to merge server and client in separate branches before merging them in `dev`. This branches are so useless.