### PR TITLE
feat: add a `Config` singleton class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ fabric.properties
 
 ### Other
 
+# Configuration files
+*.ini
+
 # Logs and temporary files
 *.log
 *.tmp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,18 +26,16 @@ set(RTYPE_HEADERS
         include/foo.hpp
 )
 
+link_libraries(inih::inireader spdlog::spdlog)
+
 #region Server
 add_executable(r-type_server ${RTYPE_SRC} ${RTYPE_HEADERS})
 
 target_compile_definitions(r-type_server PRIVATE RTYPE_IS_SERVER)
-
-target_link_libraries(r-type_server PRIVATE spdlog::spdlog)
 #endregion
 
 #region Client
 add_executable(r-type_client ${RTYPE_SRC} ${RTYPE_HEADERS})
 
 target_compile_definitions(r-type_client PRIVATE RTYPE_IS_CLIENT)
-
-target_link_libraries(r-type_client PRIVATE spdlog::spdlog)
 #endregion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+find_package(inih REQUIRED)
 find_package(spdlog REQUIRED)
 
 include_directories(include src)
@@ -15,6 +16,8 @@ set(RTYPE_SRC
         src/ECS/EntityManager.hpp
         src/ECS/SparseSet.hpp
         src/ECS/SystemManager.hpp
+        src/RType/Config/Config.cpp
+        src/RType/Config/Config.hpp
         src/RType/ModeManager/ModeManager.cpp
         src/RType/ModeManager/ModeManager.hpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(RTYPE_SRC
         src/ECS/EntityManager.hpp
         src/ECS/SparseSet.hpp
         src/ECS/SystemManager.hpp
+        src/RType/RType.cpp
+        src/RType/RType.hpp
         src/RType/Config/Config.cpp
         src/RType/Config/Config.hpp
         src/RType/ModeManager/ModeManager.cpp

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 You can consult the documentation [here](https://github.com/Z4RM/Epitech-Tek3-CPP-R-Type/wiki).
 
+## Configuration
+
+To configure some parts of the **R-Type** you can provide a `config.ini` file
+containing specifics configuration keys.
+
+To do this, you can copy the `config.ini.example` file to `config.ini` and
+configure each key.\
+All the keys and their possible values are explained in the example file.
+
 ## Contributing
 
 Please follow the guidelines to contribute to the project:

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,4 +1,5 @@
 [requires]
+inih/58
 spdlog/1.15.0
 
 [generators]

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,13 @@
+; This file is an example of the configuration used by the R-Type.
+; To use it, copy it to "config.ini" and customize the configuration values.
+
+[log]
+; The logging level
+; trace    | Highly detailed logs for tracing program execution.
+; debug    | Logs for debugging during development.
+; info     | Informational messages about normal operations. This is the default log level.
+; warn     | Warnings about potential issues.
+; err      | Errors that occur but don’t stop the app.
+; critical | Critical errors requiring immediate attention.
+; off      | Turns off logging completely.
+level=info

--- a/src/RType/Config/Config.cpp
+++ b/src/RType/Config/Config.cpp
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** Config.cpp
+*/
+
+#include "INIReader.h"
+#include "Config.hpp"
+
+rtype::Config::LogLevels rtype::Config::_logLevels = {
+        {"trace",    spdlog::level::trace},
+        {"debug",    spdlog::level::debug},
+        {"info",     spdlog::level::info},
+        {"warn",     spdlog::level::warn},
+        {"err",      spdlog::level::err},
+        {"critical", spdlog::level::critical},
+        {"off",      spdlog::level::off}
+};
+
+rtype::Config::Config(const std::string &filename) {
+    INIReader reader(filename);
+
+    _setLogLevel(reader);
+}
+
+void rtype::Config::_setLogLevel(const INIReader &reader) {
+    auto logLevel = reader.Get("log", "level", "");
+
+    if (!logLevel.empty()) {
+        if (_logLevels.find(logLevel) == _logLevels.end())
+            spdlog::warn("\"\33[3m" + logLevel + "\33[0m\" is not a valid log level");
+        else
+            spdlog::set_level(_logLevels[logLevel]);
+    }
+}

--- a/src/RType/Config/Config.cpp
+++ b/src/RType/Config/Config.cpp
@@ -7,7 +7,7 @@
 
 #include "Config.hpp"
 
-rtype::Config::LogLevels rtype::Config::_logLevels = {
+const rtype::Config::LogLevels rtype::Config::_logLevels = {
         {"trace",    spdlog::level::trace},
         {"debug",    spdlog::level::debug},
         {"info",     spdlog::level::info},
@@ -30,6 +30,6 @@ void rtype::Config::_setLogLevel(const INIReader &reader) {
         if (_logLevels.find(logLevel) == _logLevels.end())
             spdlog::warn("\"\33[3m" + logLevel + "\33[0m\" is not a valid log level");
         else
-            spdlog::set_level(_logLevels[logLevel]);
+            spdlog::set_level(_logLevels.at(logLevel));
     }
 }

--- a/src/RType/Config/Config.cpp
+++ b/src/RType/Config/Config.cpp
@@ -5,7 +5,6 @@
 ** Config.cpp
 */
 
-#include "INIReader.h"
 #include "Config.hpp"
 
 rtype::Config::LogLevels rtype::Config::_logLevels = {

--- a/src/RType/Config/Config.hpp
+++ b/src/RType/Config/Config.hpp
@@ -8,6 +8,7 @@
 #ifndef RTYPE_CONFIG_HPP_
 #define RTYPE_CONFIG_HPP_
 
+#include "INIReader.h"
 #include "spdlog/spdlog.h"
 
 namespace rtype {

--- a/src/RType/Config/Config.hpp
+++ b/src/RType/Config/Config.hpp
@@ -17,6 +17,7 @@ namespace rtype {
      *
      * @brief Initialize all that is needed from the configuration file (e.g. log level).
      * For configuration keys that it can't do anything with, it stores them, and they are accessible from getters.
+     * This class is a singleton, which means that it can be accessed from anywhere without passing it through all functions.
      */
     class Config {
         /**
@@ -26,14 +27,48 @@ namespace rtype {
 
     public:
         /**
-         * @brief Config's constructor.
-         * It reads and parses the config and initialize all that is needed.
+         * @brief Get the singleton instance of Config.
          *
-         * @param filename The file from which the config should be read.
+         * @param filename Optional parameter to specify the configuration file from which the configuration should be read.
+         * It will be used only during the first call.
+         *
+         * @return Reference to the Config singleton instance.
          */
-        explicit Config(const std::string &filename = "config.ini");
+        static Config &getInstance(const std::string &filename = "config.ini") {
+            static Config instance(filename);
+
+            return instance;
+        }
+
+        /**
+         * @brief Alias for `getInstance` to simply initialize the class,
+         * without returning an instance of it.
+         *
+         * @param filename Optional parameter to specify the configuration file from which the configuration should be read.
+         */
+        static void initialize(const std::string &filename = "config.ini") {
+            getInstance(filename);
+        }
+
+        //region Delete copy and move constructors to ensure singleton integrity
+        Config(const Config &) = delete;
+
+        Config &operator=(const Config &) = delete;
+
+        Config(Config &&) = delete;
+
+        Config &operator=(Config &&) = delete;
+        //endregion
 
     private:
+        /**
+         * @brief Private constructor.
+         * It reads and parses the config and initialize all that is needed.
+         *
+         * @param filename The configuration file from which the configuration should be read.
+         */
+        explicit Config(const std::string &filename);
+
         /**
          * @brief Set the spdlog log level, depending on the log level defined in the configuration file (if applicable).
          *
@@ -45,7 +80,7 @@ namespace rtype {
          * @brief Map containing the log levels.
          * It permits to get the spdlog level value from its name (as string).
          */
-        static LogLevels _logLevels;
+        static const LogLevels _logLevels;
     };
 }
 

--- a/src/RType/Config/Config.hpp
+++ b/src/RType/Config/Config.hpp
@@ -1,0 +1,51 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** Config.hpp
+*/
+
+#ifndef RTYPE_CONFIG_HPP_
+#define RTYPE_CONFIG_HPP_
+
+#include "spdlog/spdlog.h"
+
+namespace rtype {
+    /**
+     * @class Config
+     *
+     * @brief Initialize all that is needed from the configuration file (e.g. log level).
+     * For configuration keys that it can't do anything with, it stores them, and they are accessible from getters.
+     */
+    class Config {
+        /**
+         * @typedef An (unordered) map of spdlog log levels.
+         */
+        using LogLevels = std::unordered_map<std::string, spdlog::level::level_enum>;
+
+    public:
+        /**
+         * @brief Config's constructor.
+         * It reads and parses the config and initialize all that is needed.
+         *
+         * @param filename The file from which the config should be read.
+         */
+        explicit Config(const std::string &filename = "config.ini");
+
+    private:
+        /**
+         * @brief Set the spdlog log level, depending on the log level defined in the configuration file (if applicable).
+         *
+         * @param reader The INIReader where to get the configuration value from.
+         */
+        static void _setLogLevel(const INIReader &reader);
+
+        /**
+         * @brief Map containing the log levels.
+         * It permits to get the spdlog level value from its name (as string).
+         */
+        static LogLevels _logLevels;
+    };
+}
+
+#endif /* !RTYPE_CONFIG_HPP_ */

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -1,0 +1,15 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** RType.cpp
+*/
+
+#include "RType/Config/Config.hpp"
+#include "RType.hpp"
+
+int rtype::RType::run() {
+    Config config;
+
+    return 0;
+}

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -9,7 +9,6 @@
 #include "RType.hpp"
 
 int rtype::RType::run() {
-    Config config;
-
+    Config::initialize();
     return 0;
 }

--- a/src/RType/RType.hpp
+++ b/src/RType/RType.hpp
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2024
+** RType
+** File description:
+** RType.hpp
+*/
+
+#ifndef RTYPE_RTYPE_HPP_
+#define RTYPE_RTYPE_HPP_
+
+namespace rtype {
+    /**
+     * @class RType
+     *
+     * @brief The main class of the R-Type, containing, among others, the entry points.
+     */
+    class RType {
+    public:
+        /**
+         * @brief The entry point of the R-Type.
+         * Should be the only statement in the program main function, used as is:
+         * ```cpp
+         * #include "RType/RType.hpp"
+         *
+         * int main() {
+         *     return rtype::RType::run();
+         * }
+         * ```
+         *
+         * @return The exit status of the program.
+         */
+        static int run();
+    };
+}
+
+#endif /* !RTYPE_RTYPE_HPP_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,17 +5,11 @@
 ** main.cpp
 */
 
-// TODO: this is a sample code, remove it
+#include "RType/RType.hpp"
 
-#include "spdlog/spdlog.h"
-
+/**
+ * @see rtype::RType::run
+ */
 int main() {
-    #ifdef RTYPE_IS_CLIENT
-        spdlog::info("R-Type client launched");
-    #endif
-    #ifdef RTYPE_IS_SERVER
-        spdlog::info("R-Type server launched on port 4242");
-    #endif
-    spdlog::info("R-Type launched");
-    return 0;
+    return rtype::RType::run();
 }


### PR DESCRIPTION
## Description

Add a `Config` class to initialize all that is needed from a configuration file

- The class uses the inih library to parse an ini configuration file and apply it.
- It's a singleton, meaning that it's accessible from anywhere in the application.
- Actually, it only gets the log level and apply to spdlog.
- Also add a config file example and explain it in the README.

Also add a `RType` class with an entry point for the program (`RType::run`).
All code of the R-Type should come from this function and it should be the only statement in the program main function.

## Related Issue

Closes #25 

## Checklist$

- [ ] Tests
  - [x] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [x] I have tested on Linux.
  - [ ] I have tested on Windows.
- [x] Documentation
  - [x] I have documented my functions with Doxygen comments.
  - [x] I have updated the Wiki (if needed) => https://github.com/Z4RM/Epitech-Tek3-CPP-R-Type/wiki/R%E2%80%90Type-configuration.
  - [x] I have updated the README (if needed).
