### PR TITLE
build: add Makefile to "automatically" install dependencies, build...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+##
+## EPITECH PROJECT, 2025
+## R-Type
+## File description:
+## Makefile
+##
+
+# TODO: test Windows compatibility
+
+CONAN			:= $(shell command -v conan)
+
+BUILD_DIR		:= build
+
+CONAN_PRESET	:= conan-release
+
+BUILD_TYPE		:= Release
+
+.PHONY:	all
+all:	build
+
+.PHONY:	debug
+debug:
+	@$(MAKE) -s BUILD_TYPE=Debug CONAN_PRESET=conan-debug
+
+.PHONY:	install
+install:	check_conan
+	@conan profile detect -e
+	@conan install . --output-folder=$(BUILD_DIR) --build=missing --settings=build_type=${BUILD_TYPE} -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
+
+.PHONY:	configure
+configure:
+	@cmake --preset $(CONAN_PRESET) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+
+.PHONY:	build
+build:	install configure
+	@cmake --build $(BUILD_DIR) --preset $(CONAN_PRESET) --config $(BUILD_TYPE)
+
+.PHONY:	tests_run
+tests_run:
+	@ctest --build-config $(BUILD_TYPE)
+
+.PHONY:	clean
+clean:
+	@rm -rf $(BUILD_DIR)
+
+.PHONY:	re
+re:	fclean all
+
+.PHONY:	fclean
+fclean:	clean
+	@rm -f CMakeUserPresets.json
+	@rm -f conan_provider.cmake
+	@rm -rf Testing
+
+.PHONY:	help
+help:
+	@echo "Available targets:"
+	@echo "    all             Install dependencies, configure, and build."
+	@echo "    debug           Same as 'all', but with a 'Debug' build type. 'BUILT_TYPE=<Type>' and 'CONAN_PRESET=conan-<type>' can also be append to any target."
+	@echo "    install         Install dependencies using Conan."
+	@echo "    configure       Configure the project using CMake."
+	@echo "    build           Build the project using CMake."
+	@echo "    tests_run       Run the tests of the project."
+	@echo "    clean           Clean the build directory."
+	@echo "    re              Clean the build directory, install dependencies, configure, and build."
+	@echo "    fclean          Force clean (remove all generated files)."
+	@echo "    help            Display this help and exit."
+
+check_conan:
+ifndef CONAN
+	@echo "Conan not found, trying to install it..."
+	@pip install conan || (echo "Could not install Conan, please install it manually: https://conan.io/downloads."; exit 1)
+endif

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ else
 endif
 
 .PHONY:	re
-re:	fclean all
+re:	clean all
 
 .PHONY:	fclean
 fclean:	clean


### PR DESCRIPTION
## Description

Add a Makefile to "automatically" install dependencies, build, etc, so it's easier to, among others, build.

## Related Issue

Closes #52 

## Checklist

- [x] Tests
  - [x] I have tested these changes.
  - [x] I have tested on Linux.
  - [x] I have tested on Windows.
- [ ] Documentation
  - [ ] I have updated the Wiki (if needed).
  - [ ] I have updated the README (if needed).
  - [ ] I have documented for Linux AND Windows (if different).
