### PR TITLE
refactor: use server address from config

### DIFF
--- a/src/ECS/SparseSet.hpp
+++ b/src/ECS/SparseSet.hpp
@@ -60,7 +60,7 @@ namespace rtype::ecs
          *
          * @param entity The unique ID of the entity.
          */
-        void removeComponent(unsigned int entity) {
+        void removeComponent(unsigned int entity) override {
             std::lock_guard lock(_mutex);
             if (_sparse.find(entity) != _sparse.end()) {
                 size_t index = _sparse[entity];

--- a/src/Network/TCPNetwork/TCPNetwork.cpp
+++ b/src/Network/TCPNetwork/TCPNetwork.cpp
@@ -10,7 +10,7 @@
 
 #include "RType/ModeManager/ModeManager.hpp"
 #include "Packets.hpp"
-
+#include "RType/Config/Config.hpp"
 
 namespace rtype::network {
 
@@ -20,13 +20,15 @@ namespace rtype::network {
         if (IS_SERVER) {
             this->_acceptor = asio::ip::tcp::acceptor(this->_ioContext, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port));
         } else {
+            const auto address = Config::getInstance().getNetwork().server.address;
+
             this->_socket = std::make_shared<asio::ip::tcp::socket>(this->_ioContext);
             try {
-                asio::ip::tcp::endpoint serverEndpoint(asio::ip::make_address("127.0.0.1"), port);
+                asio::ip::tcp::endpoint serverEndpoint(asio::ip::make_address(address), port);
                 this->connect(serverEndpoint);
                 this->handleClient(this->_socket);
             } catch (std::exception &e) {
-                spdlog::error("Error while creating a endpoint to the server tcp network: 127.0.0.1:{}", port);
+                spdlog::error("Error while creating a endpoint to the server tcp network: {}:{}", address, port);
             }
         }
     }

--- a/src/Network/TCPNetwork/TCPNetwork.cpp
+++ b/src/Network/TCPNetwork/TCPNetwork.cpp
@@ -98,7 +98,8 @@ namespace rtype::network {
                 handlePacket(*buffer, socket);
                 handleClient(socket);
             } else {
-                if (error == asio::error::eof) {
+                // On Linux, the error code is `asio::error::eof`, but on Windows, it's `asio::error::connection_reset`
+                if (error == asio::error::eof || error == asio::error::connection_reset) {
                     spdlog::warn("TCP Remote {}:{} closed the connection", address, port);
                     this->_onPlayerDisconnect(socket);
                 } else {

--- a/src/Network/UDPNetwork/UDPNetwork.cpp
+++ b/src/Network/UDPNetwork/UDPNetwork.cpp
@@ -10,6 +10,7 @@
 #include <Network/Packets/EPacketCode.hpp>
 #include "RType/ModeManager/ModeManager.hpp"
 #include "Packets.hpp"
+#include "RType/Config/Config.hpp"
 
 namespace rtype::network {
 
@@ -19,9 +20,9 @@ namespace rtype::network {
         } else {
             this->_socket = std::make_shared<asio::ip::udp::socket>(this->_ioContext, asio::ip::udp::endpoint(asio::ip::udp::v4(), 0));
             try {
-                this->_serverEndpoint = asio::ip::udp::endpoint(asio::ip::make_address("127.0.0.1"), port);
+                this->_serverEndpoint = asio::ip::udp::endpoint(asio::ip::make_address(Config::getInstance().getNetwork().server.address), port);
             } catch (std::exception &e) {
-                spdlog::error("Error while creating server endpoint", port);
+                spdlog::error("Error while creating server endpoint");
             }
         }
     }

--- a/src/RType/Config/Config.hpp
+++ b/src/RType/Config/Config.hpp
@@ -35,12 +35,11 @@ namespace rtype {
              * @brief The server configuration.
              */
             struct {
-#ifdef RTYPE_IS_CLIENT
                 /**
                  * @brief The address of the server.
                  */
                 std::string address;
-#endif
+
                 /**
                  * @brief The port of the server.
                  */

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -22,15 +22,6 @@
 #include "Entities/Window.hpp"
 #endif
 
-int rtype::RType::run() {
-    if (!Config::initialize())
-        return 84;
-
-    RType rtype(Config::getInstance().getNetwork().server.port);
-
-    return rtype._run();
-}
-
 #ifdef RTYPE_IS_CLIENT
 
 void rtype::RType::startServer() {
@@ -53,9 +44,10 @@ void rtype::RType::stopServer() {
 
 #endif
 
-rtype::RType::RType(unsigned short port) : _port(port) {}
+int rtype::RType::run() {
+    if (!Config::initialize())
+        return 84;
 
-int rtype::RType::_run() {
     ecs::EntityManager entityManager;
     ecs::ComponentManager componentManager;
     ecs::SystemManager systemManager;
@@ -108,7 +100,7 @@ int rtype::RType::_run() {
         }
 
         if (runningStoppedCount > 0) {
-            spdlog::warn("stop");
+            spdlog::debug("Program stopped");
             break;
         }
         sceneManager.updateCurrentScene(systemManager);

--- a/src/RType/RType.hpp
+++ b/src/RType/RType.hpp
@@ -38,19 +38,6 @@ namespace rtype {
         // TODO: documentation
         void stopServer();
 #endif
-
-    private:
-        // TODO: documentation
-        explicit RType(unsigned short port);
-
-        // TODO: documentation
-        int _run();
-
-        // TODO: documentation
-        bool _running();
-
-        // TODO: documentation
-        unsigned short _port;
     };
 }
 


### PR DESCRIPTION
## Description

The client was always using "127.0.0.1" as server address. Now, it uses the address from the config file.
Also catch connection reset error in addition of EOF error, because it's the error that the server receives on Windows when a client disconnects.

## Checklist

- [ ] Tests
  - [x] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [x] I have tested on Linux.
  - [x] I have tested on Windows.
