### PR TITLE
refactor(logs): use appropriate log levels and rewrite log messages

### DIFF
--- a/src/ECS/Scene/SceneManager.hpp
+++ b/src/ECS/Scene/SceneManager.hpp
@@ -27,7 +27,7 @@ namespace rtype::ecs {
 
        void registerScene(int id, std::shared_ptr<IScene> scene) {
            if (_scenes.find(id) != _scenes.end()) {
-               spdlog::warn("Scene not loaded because already registered with id: {}", id);
+               spdlog::warn("Scene not loaded because already registered with ID {}", id);
                return;
            }
            _scenes[id] = std::move(scene);

--- a/src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.cpp
+++ b/src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.cpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2025
 ** RType
 ** File description:
-** TODO: add description
+** PacketEnemiesData.cpp
 */
 
 #include "PacketEnemiesData.hpp"

--- a/src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.hpp
+++ b/src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.hpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2025
 ** RType
 ** File description:
-** TODO: add description
+** PacketEnemiesData.hpp
 */
 
 #pragma once

--- a/src/Network/Packets/Descriptors/PacketPlayerCounter/PacketPlayerCounter.cpp
+++ b/src/Network/Packets/Descriptors/PacketPlayerCounter/PacketPlayerCounter.cpp
@@ -7,8 +7,6 @@
 
 #include "PacketPlayerCounter.hpp"
 
-#include <spdlog/spdlog.h>
-
 namespace rtype::network {
     std::vector<char> PacketPlayerCounter::bufferize() const {
         std::vector<char> buffer(sizeof(this->_code) + sizeof(this->_count));

--- a/src/Network/Packets/Descriptors/PacketPlayersData/PacketPlayersData.cpp
+++ b/src/Network/Packets/Descriptors/PacketPlayersData/PacketPlayersData.cpp
@@ -7,8 +7,6 @@
 
 #include "PacketPlayersData.hpp"
 
-#include <spdlog/spdlog.h>
-
 namespace rtype::network {
 
     std::vector<char> PacketPlayersData::bufferize() const {

--- a/src/Network/Packets/Descriptors/PacketWelcome/PacketWelcome.cpp
+++ b/src/Network/Packets/Descriptors/PacketWelcome/PacketWelcome.cpp
@@ -7,8 +7,6 @@
 
 #include "PacketWelcome.hpp"
 
-#include <spdlog/spdlog.h>
-
 namespace rtype::network {
     std::vector<char> PacketWelcome::bufferize() const {
         std::vector<char> buffer(sizeof(this->_code) + sizeof(this->netId));

--- a/src/Network/Packets/PacketFactory/PacketFactory.cpp
+++ b/src/Network/Packets/PacketFactory/PacketFactory.cpp
@@ -8,7 +8,6 @@
 #include "PacketFactory.hpp"
 
 #include <Network/Packets/EPacketCode.hpp>
-#include <spdlog/spdlog.h>
 
 #include "Network/Packets/Descriptors/PacketConnect/PacketConnect.hpp"
 #include "Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.hpp"

--- a/src/RType/Components/Client.hpp
+++ b/src/RType/Components/Client.hpp
@@ -13,3 +13,5 @@
 #include "./Client/InputHandler.hpp"
 #include "./Client/SfText.hpp"
 #include "./Client/OnClick.hpp"
+#include "./Client/SlidingBg.hpp"
+#include "./Client/Sprite.hpp"

--- a/src/RType/Components/Shared/NoDamageToPlayer.hpp
+++ b/src/RType/Components/Shared/NoDamageToPlayer.hpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2025
 ** RType
 ** File description:
-** TODO: add description
+** NoDamageToPlayer.hpp
 */
 
 #pragma once

--- a/src/RType/Config/Config.cpp
+++ b/src/RType/Config/Config.cpp
@@ -31,7 +31,7 @@ void rtype::Config::_setLogLevel(const INIReader &reader) {
 
     if (!logLevel.empty()) {
         if (_logLevels.find(logLevel) == _logLevels.end())
-            spdlog::warn("\"\33[3m" + logLevel + "\33[0m\" is not a valid log level");
+            spdlog::warn("\"\33[3m" + logLevel + "\33[0m\" is not a valid log level, ignoring this setting");
         else
             spdlog::set_level(_logLevels.at(logLevel));
     }

--- a/src/RType/Config/Config.cpp
+++ b/src/RType/Config/Config.cpp
@@ -39,7 +39,7 @@ void rtype::Config::_setLogLevel(const INIReader &reader) {
 
 void rtype::Config::_initializeNetwork(const INIReader &reader) {
 #ifdef RTYPE_IS_CLIENT
-    _network.server.address = reader.GetString("network", "server_address", "");
+    _network.server.address = reader.GetString("network", "server_address", "127.0.0.1");
     if (_network.server.address.empty())
         spdlog::warn("No server address provided, you will be able to play only with a \"local server\"");
 #endif

--- a/src/RType/Entities/Image.cpp
+++ b/src/RType/Entities/Image.cpp
@@ -5,14 +5,9 @@
 ** Image entity
 */
 
-
-#include "./Image.hpp"
-
-#include <spdlog/spdlog.h>
-
+#include "Components.hpp"
 #include "Window.hpp"
-#include "RType/Components/Client/SlidingBg.hpp"
-#include "RType/Components/Client/Sprite.hpp"
+#include "Image.hpp"
 
 namespace rtype::entities {
     Image::Image(ecs::ComponentManager &componentManager, ecs::EntityManager &entityManager, components::Sprite sprite, bool

--- a/src/RType/Entities/Player.cpp
+++ b/src/RType/Entities/Player.cpp
@@ -5,12 +5,8 @@
 ** Player.hpp
 */
 
-#include "Player.hpp"
-
-#include <iostream>
-#include <spdlog/spdlog.h>
-
 #include "RType/ModeManager/ModeManager.hpp"
+#include "Player.hpp"
 
 #ifdef RTYPE_IS_CLIENT
 

--- a/src/RType/ModeManager/ModeManager.cpp
+++ b/src/RType/ModeManager/ModeManager.cpp
@@ -19,13 +19,13 @@ bool rtype::ModeManager::isServer() {
 void rtype::ModeManager::enableServer() {
     std::lock_guard<std::mutex> lock(_modeMutex);
     _isServer = true;
-    spdlog::debug("Server mode enabled");
+    spdlog::info("Server enabled");
 }
 
 void rtype::ModeManager::disableServer() {
     std::lock_guard<std::mutex> lock(_modeMutex);
     _isServer = false;
-    spdlog::debug("Server mode disabled");
+    spdlog::info("Server disabled");
 }
 
 void rtype::ModeManager::switchServer() {

--- a/src/RType/Models/EnemyData.hpp
+++ b/src/RType/Models/EnemyData.hpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2025
 ** RType
 ** File description:
-** TODO: add description
+** EnemyData.hpp
 */
 
 #pragma once

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -66,7 +66,7 @@ int rtype::RType::run() {
     rtype::entities::RWindow renderWindow{};
     rtype::entities::Mode mode;
     mode.style.style = sf::Style::Default;
-    rtype::entities::Window window(
+    rtype::entities::Window(
             entityManager,
             componentManager,
             {800, 600},

--- a/src/RType/Systems/AnimationProjectile.cpp
+++ b/src/RType/Systems/AnimationProjectile.cpp
@@ -7,8 +7,6 @@
 
 #include "AnimationProjectile.hpp"
 
-#include <spdlog/spdlog.h>
-
 void rtype::systems::UpdateProjectilesSystem::updateProjectiles(
     ecs::EntityManager &entityManager,
     ecs::ComponentManager &componentManager

--- a/src/RType/Systems/InputSystem.cpp
+++ b/src/RType/Systems/InputSystem.cpp
@@ -5,11 +5,8 @@
 ** InputSystem.cpp
 */
 
-#include "InputSystem.hpp"
-
-#include <spdlog/spdlog.h>
-
 #include "Components.hpp"
+#include "InputSystem.hpp"
 
 void rtype::systems::InputSystem::handleInput(ecs::EntityManager &entityManager, ecs::ComponentManager &componentManager, const
  sf::Event &event, entities::RWindow *window) {

--- a/src/RType/Systems/Movement.cpp
+++ b/src/RType/Systems/Movement.cpp
@@ -1,10 +1,14 @@
-#include "Movement.hpp"
-#include "Components.hpp"
-#include <complex>
-#include <spdlog/spdlog.h>
+/*
+** EPITECH PROJECT, 2025
+** RType
+** File description:
+** InputSystem.cpp
+*/
 
-#include "RType/Components/Shared/Dead.hpp"
+#include <complex>
 #include "RType/ModeManager/ModeManager.hpp"
+#include "Components.hpp"
+#include "Movement.hpp"
 
 float rtype::systems::Movement::getDistanceBetweenPositions(const rtype::components::Position *pos1,
                                                             const rtype::components::Position *pos2) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,10 +13,11 @@
  * @see rtype::RType::run
  */
 int main() {
+    // TODO: remove this try/catch and catch at the right place(s)
     try {
         return  rtype::RType::run();
     } catch (std::exception &e) {
-        spdlog::error(e.what());
+        spdlog::critical(e.what());
         return 84;
     }
 }


### PR DESCRIPTION
## Description

Refactor log message (from `spdlog`) so they use better and appropriate log levels, and rewrite most of logs so they are more uniform and understandable.

Also set default server address from config to `127.0.0.1` (localhost), instead of an empty string.

## Related Issue

Closes #86 

## Checklist

- [ ] Tests
  - [x] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [x] I have tested on Linux.
  - [ ] I have tested on Windows.
