### PR TITLE
fix(menus): can start another game after last game ended

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,6 @@ set(RTYPE_SRC
         src/Network/Packets/Descriptors/PacketPlayerShoot/PacketPlayerShoot.cpp
         src/Network/Packets/Descriptors/PacketPlayerShoot/PacketPlayerShoot.hpp
         src/RType/Systems/Network/handlers/INetworkHandler.hpp
-        src/RType/Systems/Network/handlers/WelcomeHandler/WelcomeHandler.hpp
-        src/RType/Systems/Network/handlers/WelcomeHandler/WelcomeHandler.cpp
         src/RType/Systems/Network/handlers/ANetworkHandler.hpp
         src/RType/Services/PlayerService/PlayerService.cpp
         src/RType/Services/PlayerService/PlayerService.hpp
@@ -87,8 +85,6 @@ set(RTYPE_SRC
         src/RType/Systems/Network/handlers/PlayerShootHandler/PlayerShootHandler.hpp
         src/RType/Services/ProjectileService/ProjectileService.cpp
         src/RType/Services/ProjectileService/ProjectileService.hpp
-        src/RType/Systems/Network/handlers/PlayerCountHandler/PlayerCountHandler.cpp
-        src/RType/Systems/Network/handlers/PlayerCountHandler/PlayerCountHandler.hpp
         src/RType/Systems/Network/handlers/ConnectHandler/ConnectHandler.cpp
         src/RType/Systems/Network/handlers/ConnectHandler/ConnectHandler.hpp
         src/RType/Components/Shared/MenuState.hpp
@@ -100,8 +96,6 @@ set(RTYPE_SRC
         src/RType/Systems/Network/handlers/PlayerDataHandler/PlayerDataHandler.hpp
         src/Network/Packets/Descriptors/PacketEndGame/PacketEndGame.cpp
         src/Network/Packets/Descriptors/PacketEndGame/PacketEndGame.hpp
-        src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
-        src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.hpp
         src/RType/Models/EEnemyType.hpp
         src/RType/Levels/Level.hpp
         src/RType/Models/Spawn.hpp
@@ -115,11 +109,17 @@ set(RTYPE_SRC
         src/RType/Services/EnemyService/EnemyService.hpp
         src/Network/Packets/Descriptors/PacketLevelsRegistered/PacketLevelsRegistered.cpp
         src/Network/Packets/Descriptors/PacketLevelsRegistered/PacketLevelsRegistered.hpp
-        src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
-        src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.hpp
 )
 
 set(CLIENT_SRC
+        src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
+        src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.hpp
+        src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
+        src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.hpp
+        src/RType/Systems/Network/handlers/PlayerCountHandler/PlayerCountHandler.cpp
+        src/RType/Systems/Network/handlers/PlayerCountHandler/PlayerCountHandler.hpp
+        src/RType/Systems/Network/handlers/WelcomeHandler/WelcomeHandler.hpp
+        src/RType/Systems/Network/handlers/WelcomeHandler/WelcomeHandler.cpp
         src/RType/Entities/Window.cpp
         src/RType/Entities/Window.hpp
         src/RType/Systems/RenderWindow.cpp
@@ -150,6 +150,8 @@ set(CLIENT_SRC
         src/RType/Systems/AnimationProjectile.cpp
         src/RType/Systems/AnimationProjectile.hpp
         src/RType/Components/Shared/NoDamageToPlayer.hpp
+        src/RType/TextureManager/TextureManager.cpp
+        src/RType/TextureManager/TextureManager.hpp
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,63 +126,32 @@ set(CLIENT_SRC
         src/RType/Systems/RenderWindow.hpp
         src/RType/Systems/InputSystem.cpp
         src/RType/Systems/InputSystem.hpp
-        src/Network/UDPNetwork/UDPNetwork.cpp
-        src/Network/UDPNetwork/UDPNetwork.hpp
-        src/ThreadPool/ThreadPool.cpp
         include/ThreadPool.hpp
-        src/Network/TCPNetwork/TCPNetwork.cpp
-        src/Network/TCPNetwork/TCPNetwork.hpp
-        src/Network/TCPNetwork/TCPNetwork.cpp
         src/Network/Packets/IPacket.hpp
-        src/Network/Packets/PacketFactory/PacketFactory.cpp
-        src/Network/Packets/PacketFactory/PacketFactory.hpp
-        src/Network/Packets/Descriptors/PacketConnect/PacketConnect.cpp
         include/Networks.hpp
         src/RType/Components/Client/Sprite.hpp
-        src/Network/Packets/Descriptors/PacketWelcome/PacketWelcome.cpp
-        src/Network/Packets/Descriptors/PacketWelcome/PacketWelcome.hpp
-        src/RType/Components/Shared/Network.hpp
-        src/Network/Packets/Descriptors/PacketPlayersData/PacketPlayersData.cpp
-        src/Network/Packets/Descriptors/PacketPlayersData/PacketPlayersData.hpp
         src/RType/Models/PlayerData.hpp
         src/RType/Components/Shared/NetId.hpp
         src/RType/Components/Shared/ActualPlayer.hpp
         src/RType/Components/Shared/Speed.hpp
         src/RType/Components/Shared/Damage.hpp
-        src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.cpp
-        src/Network/Packets/Descriptors/PacketEnemiesData/PacketEnemiesData.hpp
         src/RType/Models/EnemyData.hpp
-        src/RType/Models/Scene.hpp
-        src/RType/Components/Shared/GameState.hpp
-        src/ECS/Scene/SceneManager.hpp
-        src/ECS/Scene/SceneManager.hpp
         src/ECS/Scene/IScene.hpp
-        src/RType/Scenes/Menu/Menu.cpp
-        src/RType/Scenes/Menu/Menu.hpp
-        src/ECS/Scene/AScene.hpp
         src/RType/Entities/Image.cpp
         src/RType/Entities/Image.hpp
         src/ECS/IEntity.hpp
         src/ECS/AEntity.hpp
-        src/ECS/AEntity.hpp
-        src/RType/Scenes/Game/Game.cpp
-        src/RType/Scenes/Game/Game.hpp
         src/RType/Components/Client/OnClick.hpp
         src/RType/Entities/Button.cpp
         src/RType/Entities/Button.hpp
         src/RType/Components/Client/SfText.hpp
         src/RType/Components/Shared/Counter.hpp
-        src/RType/Entities/Game.cpp
-        src/RType/Entities/Game.hpp
-        src/Network/Packets/Descriptors/PacketStartGame/PacketStartGame.cpp
-        src/Network/Packets/Descriptors/PacketStartGame/PacketStartGame.hpp
         src/RType/Components/Client/SlidingBg.hpp
         src/RType/Systems/AnimationProjectile.cpp
         src/RType/Systems/AnimationProjectile.hpp
         src/RType/Components/Shared/NoDamageToPlayer.hpp
-        src/RType/Systems/Network/handlers/PlayerDataHandler/PlayerDataHandler.cpp
-        src/RType/Systems/Network/handlers/PlayerDataHandler/PlayerDataHandler.hpp
 )
+
 
 set(RTYPE_HEADERS
         include/Components.hpp

--- a/src/Network/Packets/Descriptors/PacketLevelsRegistered/PacketLevelsRegistered.cpp
+++ b/src/Network/Packets/Descriptors/PacketLevelsRegistered/PacketLevelsRegistered.cpp
@@ -37,6 +37,4 @@ namespace rtype::network {
             currentSize += sizeof(this->levels[i]);
         }
     }
-
-
 }

--- a/src/Network/Packets/PacketFactory/PacketFactory.cpp
+++ b/src/Network/Packets/PacketFactory/PacketFactory.cpp
@@ -49,6 +49,7 @@ namespace rtype::network {
                 break;
             case LEVELS_REGISTERED:
                 packet = std::make_unique<PacketLevelsRegistered>();
+                break;
             case END_GAME:
                 packet = std::make_unique<PacketEndGame>();
                 break;

--- a/src/Network/TCPNetwork/TCPNetwork.cpp
+++ b/src/Network/TCPNetwork/TCPNetwork.cpp
@@ -35,7 +35,7 @@ namespace rtype::network {
 
 
     void TCPNetwork::start() {
-        int numThreads = 2;
+        int numThreads = 10;
         this->_threadPool.emplace(numThreads);
 
         if (IS_SERVER) {
@@ -50,9 +50,7 @@ namespace rtype::network {
         for (int i = 0; i < numThreads; i++) {
             this->_threadPool->addTask([this] {
                 try {
-                    while (!this->_ioContext.stopped()) {
-                        this->_ioContext.run_one();
-                    }
+                    this->_ioContext.run();
                 } catch (std::exception &e) {
                     spdlog::error("Exception in a TCP IO Thread: {}", e.what());
                 }
@@ -152,6 +150,7 @@ namespace rtype::network {
             spdlog::debug("TCP packet [{}] received from {}:{}", std::to_string(packet->getCode()), address, port);
 
             auto it = this->_netHandlers.find(packet->getCode());
+
             if (it != this->_netHandlers.end()) {
                 it->second->handle(std::move(packet), socket);
                 return;

--- a/src/Network/UDPNetwork/UDPNetwork.cpp
+++ b/src/Network/UDPNetwork/UDPNetwork.cpp
@@ -41,9 +41,7 @@ namespace rtype::network {
         for (int i = 0; i < numThreads; i++) {
             this->_threadPool->addTask([this] {
                 try {
-                    while (!this->_ioContext.stopped()) {
-                        this->_ioContext.run_one();
-                    }
+                    this->_ioContext.run();
                 } catch (std::exception &e) {
                     spdlog::error("Exception in an UDP IO Thread: {}", e.what());
                 }

--- a/src/RType/Entities/Enemy.cpp
+++ b/src/RType/Entities/Enemy.cpp
@@ -8,6 +8,8 @@
 
 #include "Enemy.hpp"
 
+#include "RType/TextureManager/TextureManager.hpp"
+
 #ifdef RTYPE_IS_CLIENT
 
 rtype::entities::Enemy::Enemy(
@@ -22,12 +24,8 @@ rtype::entities::Enemy::Enemy(
     components::Speed speed
 ) {
     _id = entityManager.createEntity();
-    sprite.texture = std::make_shared<sf::Texture>();
     sprite.sprite = std::make_shared<sf::Sprite>();
-    const int width = static_cast<int>(sprite.size.width);
-    const int height = static_cast<int>(sprite.size.height);
-    const sf::IntRect rect(0, 0, width, height);
-    sprite.texture->loadFromFile(sprite.path, rect);
+    sprite.texture = TextureManager::getInstance().getTexture("enemy");
     sprite.sprite->setTexture(*sprite.texture);
     sprite.sprite->setPosition({pos.x, pos.y});
     sprite.sprite->setScale(2, 2);

--- a/src/RType/Entities/Enemy.cpp
+++ b/src/RType/Entities/Enemy.cpp
@@ -8,9 +8,8 @@
 
 #include "Enemy.hpp"
 
-#include "RType/TextureManager/TextureManager.hpp"
-
 #ifdef RTYPE_IS_CLIENT
+#include "RType/TextureManager/TextureManager.hpp"
 
 rtype::entities::Enemy::Enemy(
     rtype::ecs::EntityManager &entityManager,

--- a/src/RType/Entities/Player.cpp
+++ b/src/RType/Entities/Player.cpp
@@ -8,6 +8,7 @@
 #include "RType/ModeManager/ModeManager.hpp"
 #include "Player.hpp"
 #include "RType/Config/Config.hpp"
+#include "RType/TextureManager/TextureManager.hpp"
 
 #ifdef RTYPE_IS_CLIENT
 
@@ -24,12 +25,8 @@ rtype::entities::Player::Player(
         const components::Speed speed
 ) {
     this->_id = entityManager.createEntity();
-    sprite.texture = std::make_shared<sf::Texture>();
     sprite.sprite = std::make_shared<sf::Sprite>();
-    const int width = static_cast<int>(sprite.size.width);
-    const int height = static_cast<int>(sprite.size.height);
-    const sf::IntRect rect(0, 0, width, height);
-    sprite.texture->loadFromFile(sprite.path, rect);
+    sprite.texture = TextureManager::getInstance().getTexture("player");
     sprite.sprite->setTexture(*sprite.texture);
     sprite.sprite->setPosition({pos.x, pos.y});
     sprite.sprite->setScale(2, 2);

--- a/src/RType/Entities/Player.cpp
+++ b/src/RType/Entities/Player.cpp
@@ -8,9 +8,9 @@
 #include "RType/ModeManager/ModeManager.hpp"
 #include "Player.hpp"
 #include "RType/Config/Config.hpp"
-#include "RType/TextureManager/TextureManager.hpp"
 
 #ifdef RTYPE_IS_CLIENT
+#include "RType/TextureManager/TextureManager.hpp"
 
 rtype::entities::Player::Player(
         rtype::ecs::EntityManager &entityManager,

--- a/src/RType/Levels/Level.hpp
+++ b/src/RType/Levels/Level.hpp
@@ -48,5 +48,7 @@ namespace rtype::levels {
          * @return true if ended, false otherwise
          * **/
         bool isGameEnded(ecs::EntityManager &entityManager, ecs::ComponentManager &componentManager);
+
+        void restoreServerState();
     };
 }

--- a/src/RType/Levels/Level.hpp
+++ b/src/RType/Levels/Level.hpp
@@ -49,6 +49,6 @@ namespace rtype::levels {
          * **/
         bool isGameEnded(ecs::EntityManager &entityManager, ecs::ComponentManager &componentManager);
 
-        void restoreServerState();
+        void endGame(ecs::EntityManager &entityManager, ecs::ComponentManager &componentManager, bool isLose);
     };
 }

--- a/src/RType/Levels/LevelManager.hpp
+++ b/src/RType/Levels/LevelManager.hpp
@@ -36,8 +36,8 @@ namespace rtype::levels {
         void reset() {
             std::lock_guard lock(_mutex);
 
-            this->_levels = {};
             this->_currentLevel = nullptr;
+            this->_levels = {};
         }
 
     private:

--- a/src/RType/Levels/LevelManager.hpp
+++ b/src/RType/Levels/LevelManager.hpp
@@ -33,6 +33,13 @@ namespace rtype::levels {
         static LevelManager &getInstance();
         void changeLevel(int number);
 
+        void reset() {
+            std::lock_guard lock(_mutex);
+
+            this->_levels = {};
+            this->_currentLevel = nullptr;
+        }
+
     private:
         LevelManager() = default;
         std::shared_ptr<Level> _currentLevel = nullptr;

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -169,6 +169,8 @@ int rtype::RType::run() {
     //TODO: put this component in the game scene instead of here
     entities::Game gameSate(componentManager, entityManager);
 
+    sceneManager.changeScene(0);
+
     while (true) {
         for (auto &entity: entityManager.getEntities()) {
             auto run = componentManager.getComponent<components::Running>(entity);

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -24,6 +24,7 @@
 #include "Systems/AnimationProjectile.hpp"
 #include "Systems/LevelRunner.hpp"
 #include "Systems/Network/Network.hpp"
+#include "TextureManager/TextureManager.hpp"
 #ifdef RTYPE_IS_CLIENT
 #include "Entities/Window.hpp"
 #endif
@@ -144,6 +145,9 @@ int rtype::RType::run() {
             renderWindow,
             mode
     );
+    TextureManager::getInstance().registerTexture("player", "assets/sprites/players.gif", {0, 0, 33, 17});
+    TextureManager::getInstance().registerTexture("enemy", "assets/sprites/enemy.gif", {0, 0, 33, 36});
+
     systemManager.addSystem(rtype::systems::RenderWindowSys::render);
     systemManager.addSystem(rtype::systems::UpdateProjectilesSystem::updateProjectiles);
 #else

--- a/src/RType/RType.cpp
+++ b/src/RType/RType.cpp
@@ -24,9 +24,10 @@
 #include "Systems/AnimationProjectile.hpp"
 #include "Systems/LevelRunner.hpp"
 #include "Systems/Network/Network.hpp"
-#include "TextureManager/TextureManager.hpp"
+
 #ifdef RTYPE_IS_CLIENT
 #include "Entities/Window.hpp"
+#include "TextureManager/TextureManager.hpp"
 #endif
 
 #ifdef RTYPE_IS_CLIENT

--- a/src/RType/Scenes/Lose/Lose.cpp
+++ b/src/RType/Scenes/Lose/Lose.cpp
@@ -59,6 +59,8 @@ void rtype::scenes::Lose::load() {
     components::MenuState state = { 0 };
 
     _componentManager.addComponent<components::MenuState>(loseSateEntity, state);
+
+    this->registerEntity(loseSateEntity);
     AScene::load();
 }
 #endif

--- a/src/RType/Scenes/Menu/Menu.cpp
+++ b/src/RType/Scenes/Menu/Menu.cpp
@@ -107,6 +107,13 @@ void rtype::scenes::Menu::load() {
     this->registerEntity(changeLevelButton);
 
     _componentManager.addComponent<components::MenuState>(menuSateEntity, state);
+
+    /*
+    if (network::TCPNetwork::getInstance().connected) {
+        network::PacketConnect packet;
+        network::TCPNetwork::getInstance().sendPacket(packet);
+    }*/
+
     AScene::load();
 }
 
@@ -116,6 +123,9 @@ void rtype::scenes::Menu::load() {
     components::MenuState state = { 0 };
 
     _componentManager.addComponent<components::MenuState>(menuSateEntity, state);
+
+    this->registerEntity(menuSateEntity);
+
     AScene::load();
 }
 #endif

--- a/src/RType/Scenes/Menu/Menu.cpp
+++ b/src/RType/Scenes/Menu/Menu.cpp
@@ -7,10 +7,14 @@
 
 #include "Menu.hpp"
 
+#include <spdlog/spdlog.h>
+
 #include "Network/Packets/Descriptors/PacketStartGame/PacketStartGame.hpp"
 #include "Network/TCPNetwork/TCPNetwork.hpp"
 #include "RType/Components/Shared/Counter.hpp"
 #include "RType/Components/Shared/MenuState.hpp"
+#include "RType/Config/Config.hpp"
+#include "RType/Entities/Game.hpp"
 #include "RType/Entities/PlayerCounter.hpp"
 #include "RType/Levels/LevelManager.hpp"
 
@@ -108,12 +112,11 @@ void rtype::scenes::Menu::load() {
 
     _componentManager.addComponent<components::MenuState>(menuSateEntity, state);
 
-    /*
-    if (network::TCPNetwork::getInstance().connected) {
+    network::TCPNetwork &network = network::TCPNetwork::getInstance(Config::getInstance().getNetwork().server.port);
+    if (network.getStarted()) {
         network::PacketConnect packet;
-        network::TCPNetwork::getInstance().sendPacket(packet);
-    }*/
-
+        network.sendPacket(packet);
+    }
     AScene::load();
 }
 

--- a/src/RType/Scenes/Win/Win.cpp
+++ b/src/RType/Scenes/Win/Win.cpp
@@ -60,6 +60,8 @@ void rtype::scenes::Win::load() {
     components::MenuState state = { 0 };
 
     _componentManager.addComponent<components::MenuState>(winSateEntity, state);
+
+    this->registerEntity(winSateEntity);
     AScene::load();
 }
 #endif

--- a/src/RType/Scenes/Win/Win.cpp
+++ b/src/RType/Scenes/Win/Win.cpp
@@ -13,6 +13,7 @@
 #include "Network/TCPNetwork/TCPNetwork.hpp"
 #include "RType/Components/Shared/MenuState.hpp"
 #include "RType/Entities/PlayerCounter.hpp"
+#include "RType/Systems/Network/Network.hpp"
 
 #ifdef RTYPE_IS_CLIENT
 #include "RType/Entities/Button.hpp"

--- a/src/RType/Systems/Network/Network.cpp
+++ b/src/RType/Systems/Network/Network.cpp
@@ -175,15 +175,15 @@ namespace rtype::systems {
                     }
                 });
 
-                if (IS_SERVER) {
+#ifndef RTYPE_IS_CLIENT
                     network.registerNetHandler(network::CONNECT, std::make_unique<ConnectHandler>(componentManager, entityManager));
                     network.registerNetHandler(network::START_GAME, std::make_unique<StartGameHandler>(componentManager, entityManager));
-                } else {
+ #else
                     network.registerNetHandler(network::WELCOME, std::make_unique<WelcomeHandler>(componentManager, entityManager));
                     network.registerNetHandler(network::PLAYER_COUNT, std::make_unique<PlayerCountHandler>(componentManager, entityManager));
                     network.registerNetHandler(network::LEVELS_REGISTERED, std::make_unique<LevelsRegisteredHandler>(componentManager, entityManager));
                     network.registerNetHandler(network::END_GAME, std::make_unique<EndGameHandler>(componentManager, entityManager));
-                }
+#endif
                 network.registerNetHandler(network::PLAYER_SHOOT, std::make_unique<PlayerShootHandler>(componentManager, entityManager));
                 network.start();
             } catch (std::exception &e) {

--- a/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
+++ b/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
@@ -17,9 +17,8 @@
 #include "RType/Components/Shared/Counter.hpp"
 #include "RType/Components/Shared/GameState.hpp"
 #include "RType/Components/Shared/Network.hpp"
-#include "RType/Entities/Window.hpp"
 #include "RType/Levels/LevelManager.hpp"
-
+#include "RType/Entities/Window.hpp"
 
 namespace rtype::systems {
     void EndGameHandler::handle(std::unique_ptr<network::IPacket> packet, std::shared_ptr<asio::ip::tcp::socket> socket) {
@@ -41,6 +40,7 @@ namespace rtype::systems {
                     _componentManager.addComponent<components::GameState>(entity, *gameState);
                     continue;
                 }
+
                 if (window)
                     continue;
 

--- a/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
+++ b/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
@@ -14,16 +14,34 @@
 #include "ECS/Scene/SceneManager.hpp"
 #include "ECS.hpp"
 #include "RType/Components/Shared/ActualPlayer.hpp"
+#include "RType/Components/Shared/Counter.hpp"
+#include "RType/Components/Shared/GameState.hpp"
 #include "RType/Components/Shared/Network.hpp"
+#include "RType/Levels/LevelManager.hpp"
+
 
 namespace rtype::systems {
     void EndGameHandler::handle(std::unique_ptr<network::IPacket> packet, std::shared_ptr<asio::ip::tcp::socket> socket) {
         auto* packetEndGame = dynamic_cast<network::PacketEndGame*>(packet.get());
 
         if (packetEndGame) {
+            levels::LevelManager::getInstance().reset();
+
             for (auto &entity : _entityManager.getEntities()) {
                 auto ai = _componentManager.getComponent<components::IA>(entity);
                 auto actualPlayer = _componentManager.getComponent<components::ActualPlayer>(entity);
+                auto gameState = _componentManager.getComponent<components::GameState>(entity);
+                auto playerCount = _componentManager.getComponent<components::Counter>(entity);
+
+                if (gameState) {
+                    gameState->isStarted = false;
+                    gameState->playerCount = 0;
+                    _componentManager.addComponent<components::GameState>(entity, *gameState);
+                }
+                if (playerCount && playerCount->name == "players") {
+                    playerCount->update(0);
+                    _componentManager.addComponent<components::Counter>(entity, *playerCount);
+                }
 
                 if (actualPlayer || ai) {
                     _entityManager.destroyEntity(entity, _componentManager);

--- a/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
+++ b/src/RType/Systems/Network/handlers/EndGameHandler/EndGameHandler.cpp
@@ -17,6 +17,7 @@
 #include "RType/Components/Shared/Counter.hpp"
 #include "RType/Components/Shared/GameState.hpp"
 #include "RType/Components/Shared/Network.hpp"
+#include "RType/Entities/Window.hpp"
 #include "RType/Levels/LevelManager.hpp"
 
 
@@ -32,20 +33,18 @@ namespace rtype::systems {
                 auto actualPlayer = _componentManager.getComponent<components::ActualPlayer>(entity);
                 auto gameState = _componentManager.getComponent<components::GameState>(entity);
                 auto playerCount = _componentManager.getComponent<components::Counter>(entity);
+                auto window = _componentManager.getComponent<entities::RWindow>(entity);
 
                 if (gameState) {
                     gameState->isStarted = false;
                     gameState->playerCount = 0;
                     _componentManager.addComponent<components::GameState>(entity, *gameState);
+                    continue;
                 }
-                if (playerCount && playerCount->name == "players") {
-                    playerCount->update(0);
-                    _componentManager.addComponent<components::Counter>(entity, *playerCount);
-                }
+                if (window)
+                    continue;
 
-                if (actualPlayer || ai) {
-                    _entityManager.destroyEntity(entity, _componentManager);
-                }
+                _entityManager.destroyEntity(entity, _componentManager);
             }
             if (packetEndGame->isLose == true) {
                 ecs::SceneManager::getInstance().changeScene(2, true);

--- a/src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
+++ b/src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
@@ -20,6 +20,8 @@ namespace rtype::systems {
         int lowestLevel = 2147483647;
 
         if (packetLevelsRegistered) {
+            levels::LevelManager::getInstance().reset();
+
             for (int level: packetLevelsRegistered->levels) {
                 levels::LevelManager::getInstance().registerLevel(std::make_shared<levels::Level>(
                     levels::LevelBuilder()
@@ -37,6 +39,7 @@ namespace rtype::systems {
                 if (counter && counter->name == "level") {
                     counter->update(lowestLevel);
                     _componentManager.addComponent<components::Counter>(entity, *counter);
+                    spdlog::warn("updated counter level");
                     return;
                 }
             }

--- a/src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
+++ b/src/RType/Systems/Network/handlers/LevelsRegisteredHandler/LevelsRegisteredHandler.cpp
@@ -39,7 +39,6 @@ namespace rtype::systems {
                 if (counter && counter->name == "level") {
                     counter->update(lowestLevel);
                     _componentManager.addComponent<components::Counter>(entity, *counter);
-                    spdlog::warn("updated counter level");
                     return;
                 }
             }

--- a/src/RType/TextureManager/TextureManager.cpp
+++ b/src/RType/TextureManager/TextureManager.cpp
@@ -1,0 +1,25 @@
+/*
+** EPITECH PROJECT, 2025
+** RType
+** File description:
+** Texture manager
+*/
+
+#include "TextureManager.hpp"
+
+namespace rtype {
+    std::shared_ptr<sf::Texture> TextureManager::getTexture(std::string key) {
+        if (this->_textures.find(key) != this->_textures.end()) {
+            return this->_textures[key];
+        }
+        return nullptr;
+    }
+
+    void TextureManager::registerTexture(std::string key, std::string path, sf::IntRect rect) {
+        std::shared_ptr<sf::Texture> texture = std::make_shared<sf::Texture>();
+
+        texture->loadFromFile(path, rect);
+        this->_textures[key] = texture;
+    }
+
+}

--- a/src/RType/TextureManager/TextureManager.hpp
+++ b/src/RType/TextureManager/TextureManager.hpp
@@ -1,0 +1,31 @@
+/*
+** EPITECH PROJECT, 2025
+** RType
+** File description:
+** TextureManager
+*/
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <SFML/Graphics/Texture.hpp>
+
+namespace rtype {
+    class TextureManager {
+    public:
+        static TextureManager &getInstance() {
+            static TextureManager instance;
+
+            return instance;
+        }
+
+        std::shared_ptr<sf::Texture> getTexture(std::string key);
+
+        void registerTexture(std::string key, std::string path, sf::IntRect rect);
+    private:
+        std::map<std::string, std::shared_ptr<sf::Texture>> _textures;
+
+    };
+}

--- a/src/RType/TextureManager/TextureManager.hpp
+++ b/src/RType/TextureManager/TextureManager.hpp
@@ -10,7 +10,7 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics.hpp>
 
 namespace rtype {
     class TextureManager {


### PR DESCRIPTION
## Description

can start another game after last game ended

## Related Issue

None

## Checklist

- [ ] Tests
  - [x] I have tested these changes.
  - [ ] I have added automated tests (if applicable).
  - [ ] I have tested on Linux.
  - [ ] I have tested on Windows.
- [ ] Documentation
  - [ ] I have documented my functions with Doxygen comments.
  - [x] I have updated the Wiki (if needed).
  - [ ] I have updated the README (if needed).
  - [ ] I have documented for Linux AND Windows (if different).

## Known Issues

None

## Additional Notes

None
